### PR TITLE
chore: cleanup android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,8 +89,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "tech.dojo.pay:uisdk:1.6.1"
   implementation "tech.dojo.pay:sdk:1.7.2"
-  implementation 'androidx.appcompat:appcompat:1.4.1'
-  implementation 'com.google.android.material:material:1.4.+'
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
Cleanup android dependencies to not include ones which are managed by the native android package.