### PR TITLE
Run package typecheck against build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepack": "bob build",
     "release": "release-it",


### PR DESCRIPTION
## Summary
- point package-level `npm run typecheck` at `tsconfig.build.json`
- reuse the existing build config that already excludes `example` and `example-new-architecture`
- keep the root `tsconfig.json` unchanged while avoiding example app dependency failures during package typecheck

## Validation
- `npm install --ignore-scripts --no-audit --no-fund --legacy-peer-deps`
- `npm run typecheck`

Fixes #33.